### PR TITLE
fix(docs): A few small optimizations in the API Reference doc

### DIFF
--- a/docs/api_ref.md
+++ b/docs/api_ref.md
@@ -13,13 +13,15 @@
   - [CCXOutputParams](#ccxoutputparams)
   - [Callbacks](#callbacks)
 - [Table of Contents](#table-of-contents)
-#
+
 ## initialize()
-The top-level module exposed by the SDK is `CCEverywhere`. Its default method `initialize()` is the main API used for initializing the SDK. Make sure to call it only once a page. This method returns a [CCEverywhere](#cceverywhere-object) object. 
 
-* `default: { initialize: (hostInfo: HostInfo, configParams?: ConfigParams) => null | CCEverywhere }` 
+The top-level module exposed by the SDK is `CCEverywhere`. Its default method `initialize()` is the main API used for initializing the SDK. Make sure to call it only once a page. This method returns a [CCEverywhere](#cceverywhere-object) object.
 
-__Parameters__: 
+- `default: { initialize: (hostInfo: HostInfo, configParams?: ConfigParams) => null | CCEverywhere }`
+
+__Parameters__:
+
 - hostInfo: [HostInfo](#hostinfo)
 - (optional) configParams: [ConfigParams](#configparams)
 
@@ -34,14 +36,15 @@ All four properties are required fields.
 |appVersion | { major: #, minor: #, patch: #} | your app version
 | platformCategory | string | 'web'
 
+```js
+{
+    clientId: YOUR_CLIENT_ID,
+    appName: YOUR_PROJECT_NAME,
+    appVersion: { major: 1, minor: 0 },
+    platformCategory: 'web'
+}
 ```
-    {
-        clientId: YOUR_CLIENT_ID,
-        appName: YOUR_PROJECT_NAME,
-        appVersion: { major: 1, minor: 0 },
-        platformCategory: 'web'
-    }
-```
+
 A folder named `appName` is created in the user's CCX account, and projects they make will be saved there.
 
 ### ConfigParams
@@ -50,15 +53,15 @@ A folder named `appName` is created in the user's CCX account, and projects they
 This is an optional field, and defaults to 'en_US' if nothing is specified.
 | Property | Type |
 | :-- | :--|
-|locale | string
+|locale | string |
 
+```js
+{
+    locale: 'en_US',
+}
 ```
-    {
-        locale: 'en_US',
-    }
-```
-See [customization](customization.md) for full locale list. 
 
+See [customization](customization.md) for full locale list.
 
 ---
 
@@ -69,13 +72,15 @@ See [customization](customization.md) for full locale list.
 This function creates a new design using CCEverywhere and takes an object of parameters, `createDesignParams`:
 
 __`CreateDesignParams`__ is an object with 4 optional properties:
+
 - inputParams: [CreateInputParams](#createinputparams)
 - modalParams: [ModalParams](#modalparams)
 - outputParams: [CCXOutputParams](#ccxoutputparams)
 - callbacks: [Callbacks](#callbacks)
 
 The function returns void.
-```
+
+```js
 ccEverywhere.createDesign(
     {
         modalParams: {},
@@ -104,13 +109,15 @@ ccEverywhere.createDesign(
 This method takes an object of parameters, `editDesignParams`:
 
 __`EditDesignParams`__ is an object with 4 properties:
+
 - inputParams: [EditInputParams](#editinputparams)
 - modalParams: [ModalParams](#modalparams)
 - outputParams: [CCXOutputParams](#ccxoutputparams)
 - callbacks: [Callbacks](#callbacks)
 
 Besides `inputParams`, the rest are optional fields. The function returns void.
-```
+
+```js
 ccEverywhere.editDesign(
     {
         // inputParams is the only REQUIRED parameter
@@ -130,11 +137,10 @@ ccEverywhere.editDesign(
 );
 ```
 
-
-
-# Shared Types 
+# Shared Types
 
 ## ModalParams
+
 Allows you to define the UI constraints of the CCX editor modal dialog. All the properties are optional.
 
 | Property | Type/Value |
@@ -143,50 +149,51 @@ Allows you to define the UI constraints of the CCX editor modal dialog. All the 
 |size | { width: #, height: #, unit: "px"/"in"/"mm"}
 | padding | number
 | borderRadius | number
-<br></br>
 
 ---
 
 ## CreateInputParams
+
 Allows you to specify the canvas template layout ratio, canvas template type, and the search text to pass in the target application (CCX Editor Component, etc). All the properties are optional. To see the full list of canvas template layout ratios and template types, see the [customization](customization.md) page.
 | Property | Type/Value |
 | :-- | :--|
 | canvasAspectId| string
 | templateType | string
 | templateSearchText | string
-<br></br>
 
 ---
 
 ## EditInputParams
-Allows you to specify the project ID the target application (CCX Editor Component, etc). 
+
+Allows you to specify the project ID the target application (CCX Editor Component, etc).
 | Property | Type |
 | :-- | :--|
 | projectId| string
 <!-- | asset | (for quick actions- uploads) -->
 
 You get this `projectId` from `publishParams` after you save a project. Refer to the [callbacks](#callbacks) sections.
-<br></br>
 
 ---
 
 ## CCXOutputParams
-All properties are optional. As of this version, the only supported output type is a base64 rendition of the project. 
+
+All properties are optional. As of this version, the only supported output type is a base64 rendition of the project.
 | Property | Value |
 | :-- | :--|
+| fileType | "jpeg", "png", or "pdf" |
 <!-- | outputType | "base64" -->
-| fileType | "jpeg", "png", or "pdf"
-<br></br>
 
 ---
 
 ## Callbacks
-All the callbacks are optional and return void. 
-The only callback function that is passed parameters is PublishCallback: `publishParams`. 
 
-Parameters for `publishParams`: 
-* projectId: string
-* asset: string (base 64 representation of output)
+All the callbacks are optional and return void.
+The only callback function that is passed parameters is PublishCallback: `publishParams`.
+
+Parameters for `publishParams`:
+
+- projectId: string
+- asset: string (base 64 representation of output)
   
 | Property | Callback Function |
 | :-- | :--|
@@ -194,20 +201,19 @@ Parameters for `publishParams`:
 | onLoad | LoadCallback
 | onCancel | CancelCallback
 | onPublishStart | PublishStartCallback
-| onPublish | **PublishCallback**
+| onPublish | __PublishCallback__
 | onError | ErrorCallback`<ErrorCode>`
-<br></br>
 
-
---- 
+---
 
 # Table of Contents
-* [Overview](../README.md)
-* [Configuration](configuration.md)
-* [Local Development](local_dev.md)
-* [Quick Start](quickstart.md)
-* [CCX Editor Component](#ccx-editor-component)
-  * [Create Project API](create_project.md)
-  * [Open Project API](edit_project.md)
-* [API References](api_ref.md)
-* [Customization](customization.md)
+
+- [Overview](../README.md)
+- [Configuration](configuration.md)
+- [Local Development](local_dev.md)
+- [Quick Start](quickstart.md)
+- [CCX Editor Component](#ccx-editor-component)
+  - [Create Project API](create_project.md)
+  - [Open Project API](edit_project.md)
+- [API References](api_ref.md)
+- [Customization](customization.md)


### PR DESCRIPTION
A few optimizations in the API References document (`api_ref.md`).

Nothing big. Fixing a small table formatting bug (comments may not exist between rows), other than that, it's mostly Markdown Lint suggestions (consistent list style types, etc.)