### PR TITLE
fix broken hyperlinks, update export options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   * [Quick Actions API](docs/quick_actions.md)
 * [API References](docs/api_ref.md)
 * [Customization](docs/customization.md)
+* [Sample](sample/README.md)
 #
 
 CC Everywhere SDK is an easy-to-integrate, customizable, all-in-one JavaScript library that brings CC Express (CCX) capabilities to all applications. Designed to support web (and in the future, mobile) platforms, over time it will include live template generation and other modular building blocks for content-first, task-based creative tooling drawn from CCX. 
@@ -54,6 +55,7 @@ After the user launches the CCX editor component upon any user interaction you s
   * Reverse Video
   * Trim Video
 
+Read more about the Quick Actions API [here](docs/quick_actions.md).
 
 ---
 

--- a/docs/api_ref.md
+++ b/docs/api_ref.md
@@ -18,8 +18,7 @@
   - [EditInputParams](#editinputparams)
   - [ExportOption](#exportoption)
     - [ExportButton](#exportbutton)
-    - [ExportButtonGroup](#exportbuttongroup)
-    - [CustomExportButton: Custom Button Clicks](#customexportbutton-custom-button-clicks)
+      - [__label__](#label)
     - [NativeExportButton: Render a Native Button](#nativeexportbutton-render-a-native-button)
     - [Example](#example)
   - [ModalParams](#modalparams)
@@ -179,7 +178,7 @@ An Asset type has three properties:
 
 | Property | Value(s)
 |:-- | :--
-| type | 'image' or 'video'
+| type | 'image'
 | dataType | 'base64'
 | data | string (base 64 representation of output)
  
@@ -188,7 +187,7 @@ An Asset type has three properties:
 An OutputAsset type has an additional property, and 2 optional properties.
 | Property | Value(s)
 |:-- | :--
-| type | 'image' or 'video'
+| type | 'image'
 | dataType | 'base64'
 | data | string (base 64 representation of output)
 | fileType | 'jpeg', 'pdf', 'png', 'mp4'
@@ -261,38 +260,22 @@ Allows you to specify the project ID the target application (CCX Editor Componen
 
 ---
 ## ExportOption
-This interface describes the base object for export buttons and groups. Allows you to define export buttons and groups for a Quick Action. All the properties are optional.
+Allows you to define export buttons and groups for a Quick Action. All the properties are optional. Must be specified in [QuickActionsInputParams](#quickactioninputparams) - it can be an empty array.
 
 
 ### ExportButton 
-This interface describes the base object that is used to render a button once the quick action has completed the action. 
+This interface describes the base object that is used to render a button once the quick action has completed the action.  
+
 | Property | Value | Description
 | :-- | :--|:--
 |optionType| "button" | QA renders single standalone button
-|label| string | Export label name
+|[label](#label)| string | Export label name
 |variant | "cta"/"primary"/"secondary" | Defines the [style](https://spectrum.adobe.com/page/button/) of a button.
-| buttonType | 'custom' or 'native' | Type of export button ([Custom](#customexportbutton-custom-button-clicks)/[Native](#nativeexportbutton-render-a-native-button))
+| buttonType | 'native' | Type of export button ([Native](#nativeexportbutton-render-a-native-button))
 | optionType | 'button' | Type of ExportOption 
 
-### ExportButtonGroup
-This interface describes the object that is used to render a group of buttons which will be shown as a drop down under a parent button. 
-| Property | Value | Description
-| :-- | :--|:--
-|optionType| "group" | QA renders drop-down button
-|label| string | Export label name
-|variant | "cta"/"primary"/"secondary" | Defines the [style](https://spectrum.adobe.com/page/button/) of a button.
-| buttons | array of [ExportButton](#export-button) | List of buttons under a dropdown menu
-
-
-### CustomExportButton: Custom Button Clicks
-
-This interface describes an object that is used to render a custom button once the quick action has completed the action.  On button click, the id will be passed back in the `onPublish` callback, along with the asset data. 
-| Property | Value | Description
-| :-- | :--|:--
-|id| string | ID of the export button 
-|label| string | Localized text of the export button
-|target | 'Host' | Used to render a custom button. Currently only 'Host'.
-| buttonType | 'custom' | Type of button
+#### __label__
+"label" defaults to "Customize" when the target is "Editor" and "Download" when the target is "Download".
 
 ### NativeExportButton: Render a Native Button
 
@@ -303,29 +286,16 @@ This interface describes an object that is used to render a native button once t
 |          | 'new' | QA handles button click in a new tab/window
 |target | 'Download' | On click will download the asset
 |  | 'Editor' | On click will open the asset in CCX
-| buttonType | 'custom' | Type of button
+| buttonType | 'native' | Type of button
 
 ### Example
 ```
 const exportOptions = [
-    // EXPORT BUTTON GROUP 
+    
+    ** target: allows the Quick Task to determine type of export */
     {
-        label: 'Open In',
-        optionType: 'group',
-        variant: 'cta',
-        buttons: [
-        {
-            target: "Editor",
-            label: "Express",
-            buttonType: "native",
-            optionType: "button"
-        },]
-    },
-        /** target: allows the Quick Task to determine type of export */
-    {
-        target: 'Host',
-        id: '@id/random',
-        label: 'Save in Your App',
+        // Customize in Express button
+        target: 'Editor',
         variant: 'cta',
         optionType: 'button',
         buttonType: 'custom'
@@ -364,15 +334,16 @@ Allows you to specify the asset and export buttons/groups you want to perform a 
 ---
 
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,18 +1,19 @@
 # Configuration Steps
 
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)
 #
 
 

--- a/docs/create_project.md
+++ b/docs/create_project.md
@@ -1,17 +1,18 @@
 # Creating a Project
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)
 #
 ## Create Project in CCX Editor: Create Project API
 Users can launch a new project in a CCX editor, using the Create Project API. The CCEverywhere Object exposes this API with the `createDesign()` method.
@@ -26,7 +27,7 @@ This function creates a new design using CCEverywhere and takes an object of par
 * [modalParams](api_ref.md#modalparams): determines size of CCX editor modal
 * [inputParams](api_ref.md#createinputparams) canvasAspectId, template types, template search
 * [outputParams](api_ref.md#ccxoutputparams): output type
-* [Callbacks](api_ref.md#callbacks) 
+* [callbacks](api_ref.md#callbacks) 
 
 ```
 ccEverywhere.createDesign(
@@ -61,59 +62,60 @@ When the "createDesign" button is clicked, the Create Project API is called and 
     <title>Create Project Sample</title>
   </head>  
   <body>
-    <button id="createDesign">Create project</button>
-    <img id="savedDesign" height="420" width="420" />
+    <button id="create-project-button">Create project</button>
+    <img id="image-container" height="420" width="420" />
 
     <script type="text/javascript" src="./CCEverywhere.js"></script>
     <script type="text/javascript">
-        // Initialize projectId to null until it gets set by onPublish callback
-        var projectId = null;
-        // Set to null until CCEverywhere object is initialized
-        var ccEverywhere = null;
-        var imageData = document.getElementById("savedDesign");
-        const createButton = document.getElementById("createDesign");
-        
-        ccEverywhere = CCEverywhere.default.initialize(
-            {
-                clientId: YOUR_CLIENT_ID,
-                appName: PROJECT_NAME,
-                appVersion: { major: 1, minor: 0 },
-                platformCategory: 'web'
-            }
-        );
 
-        createButton.onclick = () => {
-            const createDesignCallback = {
-                onCancel: () => {},
-                onPublish: (publishParams) => {
-                    // User clicked "Save"
-                    // Save image data to render in sample
-                    // Save projectId for editing later
-                    const localData = { 
-                        project: publishParams.projectId, 
-                        image: publishParams.asset.data 
-                    };
-                    imageData.src = localData.image;
-                    projectId = localData.project; 
-                },
-                onError: (err) => {
-                    console.error('Error received is', err.toString());
-                },
-            };
-    
-            ccEverywhere.createDesign(
-                {
-                    callbacks: createDesignCallback
-                }
-            );  
+    /* Initialize projectId to null until it gets set by onPublish callback */
+    var projectId = null;
+    /* Set to null until CCEverywhere object is initialized */
+    var ccEverywhere = null;
+    var imageContainer = document.getElementById("image-container");
+    const createButton = document.getElementById("create-project-button");
+        
+    ccEverywhere = CCEverywhere.default.initialize(
+        {
+            clientId: YOUR_CLIENT_ID,
+            appName: PROJECT_NAME,
+            appVersion: { major: 1, minor: 0 },
+            platformCategory: 'web'
         }
+    );
+
+    createButton.onclick = () => {
+        const createDesignCallback = {
+            onCancel: () => {},
+            onPublish: (publishParams) => {
+                /* User clicked "Save"
+                   Save image data to render in sample
+                   Save projectId for editing later */
+                const localData = { 
+                    project: publishParams.projectId, 
+                    image: publishParams.asset.data 
+                };
+                imageContainer.src = localData.image;
+                projectId = localData.project; 
+            },
+            onError: (err) => {
+                console.error('Error received is', err.toString());
+            },
+        };
+    
+        ccEverywhere.createDesign(
+            {
+                callbacks: createDesignCallback
+            }
+        );  
+    }
     </script>
   </body> 
 </html>
 ```
 __Notes__:
 - When `onPublish` is called, we save the project ID in a global variable `projectId` so we can use it to modify the same project later.
-- "savedDesign" is the ID of an image element, and its source tag is updated to reflect user's project creations and edits. "createDesign" is the ID of a button element, and click events on this button launch the editor.
+- "imageContainer" is the ID of an image element, and its source tag is updated to reflect user's project creations and edits. "create-project-button" is the ID of a button element, and click events on this button launch the editor.
 
 
 Now that you have created a project and rendered the final design onto your own page, let's explore the [Open Project API](edit_project.md) to see how you can launch the editor to make changes to existing projects.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,17 +1,18 @@
 # Customization 
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)
 #
 
 ## Locale

--- a/docs/edit_project.md
+++ b/docs/edit_project.md
@@ -1,18 +1,19 @@
 # CCX Editor: Editing an existing project
 
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)
 #
 ## Edit Project in CCX Editor: Open Project API
 Users are able to keep working on existing projects within the editor, using our Open Project API. The CCEverywhere Object exposes a `editDesign()` method. 
@@ -25,12 +26,12 @@ This function edits an existing design using CCEverywhere and takes an object of
 * [modalParams](api_ref.md#modalparams): determines size of CCX editor modal
 * [inputParams](api_ref.md#editinputparams): projectId
 * [outputParams](api_ref.md#ccxoutputparams): output type
-* [Callbacks](api_ref.md#callbacks) 
+* [callbacks](api_ref.md#callbacks) 
 
 ```
 ccEverywhere.editDesign(
     {
-        // inputParams is the only REQUIRED parameter
+    /* inputParams.projectId is the only required parameter */
         inputParams: { 
             projectId: CCX_PROJECT_ID 
         },
@@ -50,7 +51,7 @@ Read more about each parameter in the [API references](api_ref.md).
 
 #
 ## Example
-When the "editDesign" button is clicked, the Open Project API is passed the current projectId saved as a global variable and the CCX editor launches that project in a modal.
+When the "editButton" button is clicked, the Open Project API is passed the current projectId saved as a global variable and the CCX editor launches that project in a modal.
 ```
 <!DOCTYPE html>
 <html lang="en">
@@ -58,51 +59,51 @@ When the "editDesign" button is clicked, the Open Project API is passed the curr
     <title>Edit Project Sample</title>
   </head>  
   <body>
-    <button id="editDesign">Edit project</button>
-    <img id="savedDesign" height="420" width="420" />
+    <button id="edit-project-button">Edit project</button>
+    <img id="image-container" height="420" width="420" />
 
     <script type="text/javascript" src="./CCEverywhere.js"></script>
     <script type="text/javascript">
-        // Set to null until CCEverywhere object is initialized
-        var ccEverywhere = null;
-        var projectId = ***set by createDesign onPublish earlier***
-        var imageData = document.getElementById("savedDesign");
+    /* Set to null until CCEverywhere object is initialized */
+    var ccEverywhere = null;
+    var projectId = <set by createDesign onPublish earlier>
+    var imageContainer = document.getElementById("image-container");
 
-        const editButton = document.getElementById("editDesign");
-    
-        ccEverywhere = CCEverywhere.default.initialize(
+    const editButton = document.getElementById("edit-project-button");
+
+    ccEverywhere = CCEverywhere.default.initialize(
+        {
+            clientId: YOUR_CLIENT_ID
+            appName: PROJECT_NAME,
+            appVersion: { major: 1, minor: 0 },
+            platformCategory: 'web'
+        }
+    );
+
+    editButton.onclick = () => {
+        const editDesignCallback = {
+            onCancel: () => {},
+            onPublish: (publishParams) => {
+            /* User clicked "Save" - done modifying project.
+            Save modified image data and projectId */
+                const localData = { 
+                    project: publishParams.projectId, 
+                    image: publishParams.asset.data 
+                };
+                imageContainer.src = localData.image;
+                projectId = localData.project;
+            },
+            onError: (err) => {
+                console.error('Error received is', err.toString());
+            },
+        };
+        ccEverywhere.editDesign(
             {
-                clientId: YOUR_CLIENT_ID
-                appName: PROJECT_NAME,
-                appVersion: { major: 1, minor: 0 },
-                platformCategory: 'web'
+                inputParams: { projectId: projectId },
+                callbacks: editDesignCallback
             }
         );
-
-        editButton.onclick = () => {
-            const editDesignCallback = {
-                onCancel: () => {},
-                onPublish: (publishParams) => {
-                    // User clicked "Save" - done modifying project
-                    // Save modified image data and projectId 
-                    const localData = { 
-                        project: publishParams.projectId, 
-                        image: publishParams.asset.data 
-                    };
-                    imageData.src = localData.image;
-                    projectId = localData.project;
-                },
-                onError: (err) => {
-                    console.error('Error received is', err.toString());
-                },
-            };
-            ccEverywhere.editDesign(
-                {
-                    inputParams: { projectId: projectId },
-                    callbacks: editDesignCallback
-                }
-            );
-        }
+    }
     </script>
   </body> 
 </html>

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -1,18 +1,19 @@
 # Local development 
 
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)
 #
 
 The CC Everywhere SDK expects requests to come from: 

--- a/docs/quick_actions.md
+++ b/docs/quick_actions.md
@@ -1,18 +1,20 @@
 # Quick Actions
 
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)
+
 #
 The Quick Actions API allows developers to harness the power of Photoshop, Acrobat, and Premiere capabilities and use it in their own application. We currently support [Image](#image-quick-actions) and [Video](#video-quick-actions) Quick Actions. In the future, we plan to add PDF Quick Actions. 
 ## Image Quick Actions 
@@ -35,7 +37,7 @@ This method triggers a CCX modal to perform the Quick Action, and takes an objec
 * id: QuickActionId
 * inputParams: [QuickActionInputParams](api_ref.md#quickactioninputparams)
   * asset: object representing data, data format, type of data
-  * exportOption: array of configurable export options (i.e. open in Express, download)
+  * exportOptions: array of configurable export options (i.e. open in Express, download)
 * [Callbacks](api_ref.md#callbacks)
 * [modalParams](api_ref.md#modalparams): determines size of CCX QA modal
 
@@ -120,10 +122,10 @@ They can then click the "Image Crop" button, which call the Quick Actions API. A
     <script type="text/javascript" >
 
     const PROJECT_NAME = 'cc everywhere';
-    // file: user uploaded file
-    // imageUrl: base64 representation we pass into QA function
+    /* file: user uploaded file
+    imageUrl: base64 representation we pass into QA function */
     var file, imageUrl;
-    // appImage is the image container displayed in sample 
+    /*  appImage is the image container displayed in sample */
     var appImage = document.getElementById('image-container');
 
     /* This event listener checks to see if the user uploads a new file and reads it into base64 data type for SDK ingestion later */
@@ -132,11 +134,11 @@ They can then click the "Image Crop" button, which call the Quick Actions API. A
     .addEventListener('change', (e) => {
         const reader = new FileReader();
         file = e.target.files[0];
-        // reads file into base 64 data type
+        /* reads file into base 64 data type */
         reader.readAsDataURL(file);
         reader.onload = () => {
             let encodedImage = reader.result;
-            //  save encoded image into imageUrl
+            /*  save encoded image into imageUrl */
             imageUrl = encodedImage;
         }
         reader.onerror = (error) => {
@@ -154,29 +156,14 @@ They can then click the "Image Crop" button, which call the Quick Actions API. A
     );
 
     const exportOptions = [
-    /* button with a drop down on click, to open in Express */
+        /* Customize export button */
         {
-            label: 'Open In',
-            optionType: 'group',
-            variant: 'cta',
-            buttons: [
-            {
-                target: "Editor",
-                label: "Express",
-                buttonType: "native",
-                optionType: "button"
-            },]
-        },
-        /* Custom export button */
-        {
-            target: 'Host',
-            id: '@id/random',
-            label: 'Save in Your App',
+            target: 'Editor',
             variant: 'cta',
             optionType: 'button',
-            buttonType: 'custom'
+            buttonType: 'native'
         },
-        /* Native export button */
+        /* Download export button */
         {
             target: 'Download',
             variant: 'primary',
@@ -237,8 +224,6 @@ They can then click the "Image Crop" button, which call the Quick Actions API. A
 
     const PROJECT_NAME = 'cc everywhere';
 
-    /* This event listener checks to see if the user uploads a new file and reads it into base64 data type for SDK ingestion later */
-
     var ccEverywhere = CCEverywhere.default.initialize(
         {
             clientId: YOUR_CLIENT_ID,
@@ -251,26 +236,20 @@ They can then click the "Image Crop" button, which call the Quick Actions API. A
     const videoCallbacks = {
         onCancel: () => {},
         onPublish: (publishParams) => {
-            const { exportButtonId, asset } = publishParams;
-            if (exportButtonId === 'open_video_new_tab') {
-                parent.window.open(asset.data, '_blank');
-            }
         },
         onError: (err) => {
             console.error('Error received is', err.toString())
         }
     }
 
-    const videoExportOptions = [
+    const exportOptions = [
         {
-            target: 'Host',
-            id: 'open_video_new_tab',
-            label: 'View in New Tab',
+            target: 'Editor',
             variant: 'cta',
             optionType: 'button',
-            buttonType: 'custom'
-            },
-            {
+            buttonType: 'native'
+        },
+        {
             target: 'Download',
             variant: 'primary',
             optionType: 'button',
@@ -283,7 +262,7 @@ They can then click the "Image Crop" button, which call the Quick Actions API. A
         ccEverywhere.openQuickAction({
             id: 'change-speed', 
             inputParams: { 
-                exportOptions: videoExportOptions
+                exportOptions: exportOptions
             },
             callbacks: videoCallbacks,
             modalParams: {},

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,18 +1,19 @@
 # Quick Start
 
 ## Table of Contents
-* [Overview](README.md)
+* [Overview](../README.md)
 * Get Started 
-  * [Configuration](docs/configuration.md)
-  * [Local Development](docs/local_dev.md)
-  * [Quick Start](docs/quickstart.md)
+  * [Configuration](configuration.md)
+  * [Local Development](local_dev.md)
+  * [Quick Start](quickstart.md)
 * SDK Components
   * CCX Editor Component
-    * [Create Project API](docs/create_project.md)
-    * [Open Project API](docs/edit_project.md)
-  * [Quick Actions API](docs/quick_actions.md)
-* [API References](docs/api_ref.md)
-* [Customization](docs/customization.md)
+    * [Create Project API](create_project.md)
+    * [Open Project API](edit_project.md)
+  * [Quick Actions API](quick_actions.md)
+* [API References](api_ref.md)
+* [Customization](customization.md)
+* [Sample](../sample/README.md)
 #
 CC Everywhere SDK lets you launch a CCX editor within your own application. This guide explains how to start using the SDK in your own app.
 
@@ -83,8 +84,10 @@ This method returns a `CCEverywhere` object, with two methods:
 
 * `createDesign()`
 * `editDesign()`
+* `openQuickAction()`
+* `exchangeAuthCodeForToken()`
 
-These methods are the ones you will use to create a new project or edit an existing one in the CCX editor. To learn more about these methods, visit the [API references](api_ref.md) page.
+These methods are the ones you will use to perform a Quick Action, or to create a new project or edit an existing one in the CCX editor. To learn more about these methods, visit the [API references](api_ref.md) page.
 
 ---
 
@@ -96,11 +99,11 @@ When you call this API, what happens is the Adobe IMS Server stores the code and
 
 We can exchange that code from an access token with the following line:
 
-```js
+`
 ccEverywhere.exchangeAuthCodeForToken();
-```
+`
 
-Create a new endpoint that simply initializes the SDK and calls this function. This endpoint should correspond to the redirect URI you provided us with. The default redirect URI we specified for our sample is "https://localhost:3000/redirect.html". This function will store that token for future requests to the SDK during this session.
+Create a new endpoint that simply initializes the SDK and calls this function. This endpoint should correspond to the redirect URI you provided us with. The default redirect URI we specified for our [sample](../sample/redirect.html) is "https://localhost:3000/redirect.html". This function will store that token for future requests to the SDK during this session.
 
 In a future build of this SDK, you will be able to specify the redirect uri you wish in the initialize function. 
 
@@ -114,3 +117,5 @@ Read more about:
 
 * How to [create a project](create_project.md) in the editor
 * How to [edit an existing project](edit_project.md) in the editor
+* How to [use Image Quick Actions](quick_actions.md#image-quick-actions)
+* How to [use Video Quick Actions](quick_actions.md#video-quick-actions)

--- a/sample/quickactions.html
+++ b/sample/quickactions.html
@@ -93,9 +93,9 @@
             </button>
             
         </ul>
-        <h2> Your edited video will appear here </h2>
+        <!-- <h2> Your edited video will appear here </h2>
         <video id="video-container" height="420" width="420" controls></video>
-    
+     -->
 
         <script type="text/javascript" src="CCEverywhere.js"></script>
         <script type="text/javascript" >
@@ -107,7 +107,7 @@
         var imageUrl;
         /* appImage is the image container displayed in sample */
         var appImage = document.getElementById('image-container');
-        var appVideo = document.getElementById('video-container');
+        // var appVideo = document.getElementById('video-container');
             
         var ccEverywhere = CCEverywhere.default.initialize(
             {
@@ -136,41 +136,28 @@
             };
         })
 
-        /* __________________________________________________________
-                        Image Quick Actions 
-        __________________________________________________________ */
-
+        /* Defines native buttons for export: 
+        "Customize" in Express, or "Download" */
         const exportOptions = [
+            /* Customize in Express */
             {
-                /* Export Button group (parent with drop down) example */
-                label: 'Open In',
-                optionType: 'group',
+                target: 'Editor',
                 variant: 'cta',
-                buttons: [
-                {
-                    target: "Editor",
-                    label: "Express",
-                    buttonType: "native",
-                    optionType: "button"
-                },]
+                buttonType: 'native',
+                optionType: 'button'
             },
-            /* Custom export button */
+            /* Download */
             {
-                target: 'Host',
-                id: '@id/random',
-                label: 'Save in Your App',
-                variant: 'cta',
-                optionType: 'button',
-                buttonType: 'custom'
-            },
-            {
-                /* Native Button example */
                 target: 'Download',
                 variant: 'primary',
                 optionType: 'button',
                 buttonType: 'native'
             }
         ];
+
+        /* __________________________________________________________
+                        Image Quick Actions 
+        __________________________________________________________ */
 
         const imageCallbacks = {
             onCancel: () => {},
@@ -235,61 +222,20 @@
         const videoCallbacks = {
             onCancel: () => {},
             onPublish: (publishParams) => {
-                const { exportButtonId, asset } = publishParams;
-                // if (exportButtonId === 'open_video_new_tab') {
-                //     parent.window.open(asset.data, '_blank');
-                // }
-                if (exportButtonId === 'open_video_app') {
-                    appVideo.src = asset.data;
-                }
+                // appVideo.src = publishParams.asset.data;
             },
             onError: (err) => {
                 console.error('Error received is', err.toString())
             }
         }
-        const videoExportOptions = [
-            // {
-            //     /* Export Button group (parent with drop down) doesn't work with video QA */
-            //     label: 'Open In',
-            //     optionType: 'group',
-            //     variant: 'cta',
-            //     buttons: [
-            //     {
-            //         target: 'Host',
-            //         id: 'open_video_app',
-            //         label: 'App',
-            //         buttonType: 'custom',
-            //         optionType: 'button'
-            //     },{
-            //         target: 'Host',
-            //         id: 'open_video_new_tab',
-            //         label: 'New tab',
-            //         button: 'custom',
-            //         optionType: 'button'
-            //     }]
-            // },
-            {
-                target: 'Host',
-                id: 'open_video_app',
-                label: 'Open in app',
-                variant: 'cta',
-                optionType: 'button',
-                buttonType: 'custom'
-            },
-            {
-                target: 'Download',
-                variant: 'primary',
-                optionType: 'button',
-                buttonType: 'native'
-            }
-        ];
+        
         function openVideoQuickAction(qa_id) {
             /* file input not supported yet, call the QA API and the user is prompted to 
             browser for image files in the modal */
             ccEverywhere.openQuickAction({
                 id: qa_id, 
                 inputParams: {
-                    exportOptions: videoExportOptions
+                    exportOptions: exportOptions
                 },
                 callbacks: videoCallbacks
             })


### PR DESCRIPTION
The two types of buttons we want 3P clients to be able to use are 1) continue to customize in Express modal and 2) download to computer. They are "native" buttons and when no 'label' is provided, they default to being labeled 'Customize' and 'Download'. 
