### PR TITLE
docs: minor fixes - use test app clientID in sample as workaround

### DIFF
--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -53,12 +53,12 @@ This will generate two files: `localhost-key.pem` (key) and `localhost.pem` (cer
 
 Install it using `npm i http-server` or `brew install http-server`.
 
-To start the server at port 3000, run this line in your project root: 
+To start the server at port 8000, run this line in your project root: 
 
 ```bash
- http-server -S -C ./localhost.pem -K ./localhost-key.pem -p 3000
+ http-server -S -C ./localhost.pem -K ./localhost-key.pem -p 8000
 ```
-By passing in our newly generated SSL key and certificate, we have enabled secure request serving with TLS/SSL (HTTPS), which we need to communicate with CCX. Now your server is up and available at `https://localhost:3000`.
+By passing in our newly generated SSL key and certificate, we have enabled secure request serving with TLS/SSL (HTTPS), which we need to communicate with CCX. Now your server is up and available at `https://localhost:8000`.
   
 
 Return to the [Quick Start](quickstart.md) guide to see how to embed the SDK in your project.  

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -103,7 +103,7 @@ We can exchange that code from an access token with the following line:
 ccEverywhere.exchangeAuthCodeForToken();
 ```
 
-Create a new endpoint that simply initializes the SDK and calls this function. This endpoint should correspond to the redirect URI you provided us with. The default redirect URI we specified for our [sample](../sample/redirect.html) is "https://localhost:3000/redirect.html". This function will store that token for future requests to the SDK during this session.
+Create a new endpoint that simply initializes the SDK and calls this function. This endpoint should correspond to the redirect URI you provided us with. The default redirect URI we specified for our [sample](../sample/redirect.html) is "https://localhost:8000/redirect.html". This function will store that token for future requests to the SDK during this session.
 
 In a future build of this SDK, you will be able to specify the redirect uri you wish in the initialize function. 
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -20,23 +20,17 @@ This will generate two files: `localhost-key.pem` (key) and `localhost.pem` (cer
 `http-server` lets you make files or directories available via `localhost`.
 
 Install it using `npm i http-server` or `brew install http-server`.
-
-To start the server at port 3000, run this line in your project root: 
-
-```
- http-server -S -C ./localhost.pem -K ./localhost-key.pem -p 3000
-```
-By passing in our newly generated SSL key and certificate, we have enabled secure request serving with TLS/SSL (HTTPS), which we need to communicate with CCX. Now your server is up and available at `https://localhost:3000`.
   
 
 ## Step 3: Run this sample
 #
-* Modify the `clientID` field in both `index.html` and `redirect.html` when you initialize the SDK. 
-* Run this line to test the sample locally: 
+1. Modify the `clientID` field in both `index.html`, `redirect.html`, and `quickactions.html` when you initialize the SDK. 
+2. To start the server at port 8000, run this line in your project root: 
 
 ```
- http-server -S -C ./localhost.pem -K ./localhost-key.pem -p 3000
+ http-server -S -C ./localhost.pem -K ./localhost-key.pem -p 8000
 ```
+By passing in our newly generated SSL key and certificate, we have enabled secure request serving with TLS/SSL (HTTPS), which we need to communicate with CCX. Now your server is up and available at `https://localhost:8000`.
 
 ## Known Issues 
 

--- a/sample/index.html
+++ b/sample/index.html
@@ -49,15 +49,16 @@
         ccEverywhere = CCEverywhere.default.initialize({
             // insert your own client ID
             clientId: '695a1c27f4e147b28d4df7a7a8c46d23',
-            // clientId: 'c352fd34caa94405ab1a2cfa736bb9f5', 
+            //clientId: 'c352fd34caa94405ab1a2cfa736bb9f5',
             // in CCX, a folder is created using this given appName and projects are saved there
             appName: PROJECT_NAME,
             appVersion: { major: 1, minor: 0 },
             platformCategory: 'web',
+            redirectUri: 'https://localhost:8000/redirect.html'
         });
         
         document.getElementById("QA").addEventListener('click', () => {
-            window.location.href = "https://localhost:3000/quickactions.html";
+            window.location.href = "https://localhost:8000/quickactions.html";
         });
 
 

--- a/sample/quickactions.html
+++ b/sample/quickactions.html
@@ -115,7 +115,8 @@
                 clientId: '695a1c27f4e147b28d4df7a7a8c46d23',
                 appName: PROJECT_NAME,
                 appVersion: { major: 1, minor: 0 },
-                platformCategory: 'web'
+                platformCategory: 'web',
+                redirectUri: 'https://localhost:8000/redirect.html'
             }
         );
 

--- a/sample/redirect.html
+++ b/sample/redirect.html
@@ -22,6 +22,7 @@
               appName: PROJECT_NAME,
               appVersion: { major: 1, minor: 0 },
               platformCategory: 'web',
+              redirectUri: 'https://localhost:8000/redirect.html'
           }
       );
       setTimeout(()=> {


### PR DESCRIPTION
As of right now, the only prod client ID working is the test app instance. It is embedded in the sample code here, and since it has https://localhost:8000/redirect.html registered as the redirect URI, that's what the sample uses as well so partners can start testing asap. Because the test app client ID has several redirect patterns registered, we *explicitly declare* the redirect URI to be used everytime the SDK is initialized.