### PR TITLE
Bump npm dependencies to non-conflicting spectrum versions

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -1,9 +1,9 @@
 {
     "dependencies": {
-        "@spectrum-css/button": "^6.0.1",
-        "@spectrum-css/expressvars": "^2.0.0",
-        "@spectrum-css/page": "^5.0.1",
-        "@spectrum-css/typography": "^4.0.19",
-        "@spectrum-css/vars": "^6.1.1"
+        "@spectrum-css/button": "^6.0.21",
+        "@spectrum-css/expressvars": "^2.0.3",
+        "@spectrum-css/page": "^5.0.15",
+        "@spectrum-css/typography": "^4.0.25",
+        "@spectrum-css/vars": "^8.0.3"
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

NPM install dependency conflict

<!--- Describe your changes in detail -->

NPM install error:

```
# npm resolution error report

While resolving: undefined@undefined
Found: @spectrum-css/vars@6.1.1
node_modules/@spectrum-css/vars
  @spectrum-css/vars@"^6.1.1" from the root project

Could not resolve dependency:
peer @spectrum-css/vars@"^8.0.0" from @spectrum-css/button@6.0.21
node_modules/@spectrum-css/button
  @spectrum-css/button@"^6.0.1" from the root project

Fix the upstream dependency conflict, or retry
this command with --force or --legacy-peer-deps
to accept an incorrect (and potentially broken) dependency resolution.
```


We can fix this by updating to the latest versions of `spectrum-css`