### PR TITLE
Ioxtd 3095 use self hosted runners dev

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,5 @@
+---
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - developer-website-arc-prd-runners-adcce

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
       run:
         shell: bash
     needs: [set-state, pre-build-dev]
-    runs-on: ubuntu-latest
+    runs-on: developer-website-arc-prd-runners-adcce
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Changes

- Update `build-dev` job in `deploy.yml` GitHub Action workflow to used `developer-website-arc-prd-runners-adcce` label so that jobs run on self-hosted GitHub Action Runners deployed on Ethos (maintained in [developer-website/ghar-deploy](https://git.corp.adobe.com/developer-website/ghar-deploy/tree/main/k8s/helm/prd/va6))

### Related Issues

- [IOXTD-3095](https://jira.corp.adobe.com/browse/IOXTD-3095)
- Re-open of [#174](https://github.com/AdobeDocs/cc-everywhere/pull/174)