### PR TITLE
concept guide for analytics addition

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -34,6 +34,7 @@
             - [In the Browser](/guides/concepts/mobile-web-support-browser.md)
             - [In a WebView](/guides/concepts/mobile-web-support-webview.md)
         - [Editor Customization](/guides/concepts/appconfig.md)
+        - [Analytics](/guides/concepts/host-app-trigger.md)
         - [V3 to V4 Migration guide](/guides/concepts/migration-v3-v4.md)
         - [Error handling](/guides/concepts/error-handling.md)
     - [Tutorials](/guides/tutorials/index.md)

--- a/src/pages/guides/concepts/host-app-trigger.md
+++ b/src/pages/guides/concepts/host-app-trigger.md
@@ -13,29 +13,31 @@ contributors:
 
 # Analytics
 
-Use `hostAppTrigger` to identify the action in your application that launched an Adobe Express Embed SDK workflow. Add it to `appConfig.analyticsData` before calling the workflow method.
-
-<InlineAlert variant="info" slots="header, text1" />
-
-#### Launch metadata, not an analytics callback
-
-`hostAppTrigger` sends launch context into the Embed SDK. It does not report user activity back to your application or replace your own analytics events or the SDK's [callbacks](../../v4/shared/src/types/callbacks-types/interfaces/callbacks.md).
-
-Use Adobe Express Embed SDK v4.26.5 or later.
+Use `hostAppTrigger` to identify the action in your application that launched an Adobe Express Embed SDK workflow. This gives Adobe consistent launch attribution and gives your team a clear mapping between host-app entry points and Adobe Express workflows when reviewing your own analytics. Add it to `appConfig.analyticsData` before calling the workflow method.
 
 ## Add `hostAppTrigger` to your integration
 
-### 1. Choose a trigger value
+### 1. Choose an example trigger value
 
-Use the value that matches the action in your application:
+The table shows example host-app actions and their corresponding values. Use the value that matches the action in your application:
 
-| Host-app action | `hostAppTrigger` value |
+| Example host-app action | `hostAppTrigger` value |
 | --- | --- |
 | Add or create an image | `"add-image"` |
 | Replace or edit an existing image | `"replace-image"` |
 | Launch a workflow from selected text | `"text-selected"` |
 
 These values are defined in the [`HostAppTrigger`](../../v4/shared/src/types/app-config-types/enumerations/host-app-trigger.md) enumeration.
+
+#### Examples
+
+The **Create with Adobe Express** action below is an example of an `"add-image"` entry point:
+
+![Create with Adobe Express action for adding an image](./img/generate-image--demo-app.png)
+
+The **Edit Image** action below is an example of a `"replace-image"` entry point:
+
+![Edit Image action for replacing or editing an image](./img/editimage_demo-app.png)
 
 ### 2. Add the value to `appConfig` and launch the workflow
 
@@ -60,11 +62,9 @@ module.createDesign(appConfig, exportConfig, containerConfig);
 
 Use the same structure with other workflows and select the appropriate value from the table above.
 
-### Full Editor and TypeScript
+### TypeScript
 
-Full Editor workflows use the same `appConfig` structure with `editor.create()` and `editor.edit()`.
-
-When using Full Editor with TypeScript, typecast `appConfig` because `analyticsData` is not yet included in the Full Editor type definition. JavaScript integrations can omit the cast.
+If TypeScript reports that `analyticsData` is not part of an `appConfig` type, typecast `appConfig`. JavaScript integrations do not need the cast.
 
 ```typescript
 const appConfig = {
@@ -72,19 +72,7 @@ const appConfig = {
     hostAppTrigger: "add-image",
   },
 } as any;
-
-editor.create(docConfig, appConfig, exportConfig, containerConfig);
 ```
-
-Use `"replace-image"` when launching `editor.edit()` for an existing design.
-
-### 3. Verify the value
-
-Test each entry point in your application:
-
-1. Set a breakpoint immediately before the SDK workflow call.
-2. Inspect `appConfig.analyticsData.hostAppTrigger`.
-3. Confirm the value matches the action that launched the workflow.
 
 ## Troubleshooting
 
@@ -92,7 +80,7 @@ Test each entry point in your application:
 | --- | --- |
 | The trigger value is missing | Verify the nesting is `appConfig.analyticsData.hostAppTrigger`. |
 | The wrong action is attributed | Confirm the value matches the table above for that entry point. |
-| TypeScript rejects Full Editor `analyticsData` | Typecast the Full Editor `appConfig` as shown above. |
+| TypeScript rejects `analyticsData` | Typecast `appConfig` as shown above. |
 
 ## Related resources
 

--- a/src/pages/guides/concepts/host-app-trigger.md
+++ b/src/pages/guides/concepts/host-app-trigger.md
@@ -13,9 +13,11 @@ contributors:
 
 # Analytics
 
-Use `hostAppTrigger` to identify the action in your application that launched an Adobe Express Embed SDK workflow. This gives Adobe consistent launch attribution and gives your team a clear mapping between host-app entry points and Adobe Express workflows when reviewing your own analytics. Add it to `appConfig.analyticsData` before calling the workflow method.
+Use `hostAppTrigger` to identify the action in your application that launched an Adobe Express Embed SDK workflow. This gives Adobe consistent launch attribution and gives your team a clear mapping between your app's entry points and Adobe Express workflows when reviewing analytics.
 
 ## Add `hostAppTrigger` to your integration
+
+Add it to `appConfig.analyticsData` before calling the workflow method.
 
 ### 1. Choose an example trigger value
 

--- a/src/pages/guides/concepts/host-app-trigger.md
+++ b/src/pages/guides/concepts/host-app-trigger.md
@@ -1,0 +1,103 @@
+---
+keywords:
+  - Adobe Express Embed SDK
+  - analyticsData
+  - hostAppTrigger
+  - HostAppTrigger
+  - appConfig
+title: Analytics
+description: Learn how to pass hostAppTrigger in analyticsData when launching an Adobe Express Embed SDK workflow.
+contributors:
+  - https://github.com/apoos-dev
+---
+
+# Analytics
+
+Use `hostAppTrigger` to identify the action in your application that launched an Adobe Express Embed SDK workflow. Add it to `appConfig.analyticsData` before calling the workflow method.
+
+<InlineAlert variant="info" slots="header, text1" />
+
+#### Launch metadata, not an analytics callback
+
+`hostAppTrigger` sends launch context into the Embed SDK. It does not report user activity back to your application or replace your own analytics events or the SDK's [callbacks](../../v4/shared/src/types/callbacks-types/interfaces/callbacks.md).
+
+Use Adobe Express Embed SDK v4.26.5 or later.
+
+## Add `hostAppTrigger` to your integration
+
+### 1. Choose a trigger value
+
+Use the value that matches the action in your application:
+
+| Host-app action | `hostAppTrigger` value |
+| --- | --- |
+| Add or create an image | `"add-image"` |
+| Replace or edit an existing image | `"replace-image"` |
+| Launch a workflow from selected text | `"text-selected"` |
+
+These values are defined in the [`HostAppTrigger`](../../v4/shared/src/types/app-config-types/enumerations/host-app-trigger.md) enumeration.
+
+### 2. Add the value to `appConfig` and launch the workflow
+
+Set `hostAppTrigger` inside `analyticsData` on the `appConfig` used for the workflow:
+
+```javascript
+await import("https://cc-embed.adobe.com/sdk/v4/CCEverywhere.js");
+
+const { module } = await window.CCEverywhere.initialize(
+  { clientId: "your-client-id", appName: "your-app-name" },
+  {}
+);
+
+const appConfig = {
+  analyticsData: {
+    hostAppTrigger: "add-image",
+  },
+};
+
+module.createDesign(appConfig, exportConfig, containerConfig);
+```
+
+Use the same structure with other workflows and select the appropriate value from the table above.
+
+### Full Editor and TypeScript
+
+Full Editor workflows use the same `appConfig` structure with `editor.create()` and `editor.edit()`.
+
+When using Full Editor with TypeScript, typecast `appConfig` because `analyticsData` is not yet included in the Full Editor type definition. JavaScript integrations can omit the cast.
+
+```typescript
+const appConfig = {
+  analyticsData: {
+    hostAppTrigger: "add-image",
+  },
+} as any;
+
+editor.create(docConfig, appConfig, exportConfig, containerConfig);
+```
+
+Use `"replace-image"` when launching `editor.edit()` for an existing design.
+
+### 3. Verify the value
+
+Test each entry point in your application:
+
+1. Set a breakpoint immediately before the SDK workflow call.
+2. Inspect `appConfig.analyticsData.hostAppTrigger`.
+3. Confirm the value matches the action that launched the workflow.
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| The trigger value is missing | Verify the nesting is `appConfig.analyticsData.hostAppTrigger`. |
+| The wrong action is attributed | Confirm the value matches the table above for that entry point. |
+| TypeScript rejects Full Editor `analyticsData` | Typecast the Full Editor `appConfig` as shown above. |
+
+## Related resources
+
+- [`HostAppTrigger` enumeration](../../v4/shared/src/types/app-config-types/enumerations/host-app-trigger.md)
+- [`BaseAnalyticsData` interface](../../v4/shared/src/types/app-config-types/interfaces/base-analytics-data.md)
+- [Third-party `AppConfig` interface](../../v4/shared/src/types/3p/app-config-types/interfaces/app-config.md)
+- [`ModuleWorkflow` API reference](../../v4/sdk/src/workflows/3p/module-workflow/classes/module-workflow.md)
+- [`EditorWorkflow` API reference](../../v4/sdk/src/workflows/3p/editor-workflow/classes/editor-workflow.md)


### PR DESCRIPTION
## Description

Adds an Analytics concept guide explaining how partners can pass `hostAppTrigger` through `appConfig.analyticsData` when launching an Adobe Express Embed SDK workflow.

The guide includes:

- Supported trigger values: `add-image`, `replace-image`, and `text-selected`
- A module workflow example
- TypeScript typecasting guidance for Full Editor
- Verification and troubleshooting steps
- Links to the relevant API references

Also adds the guide to the Concepts navigation as **Analytics**.

## Related Issue

<!-- Add the related GitHub issue or Jira link here. -->

## Motivation and Context

Partners need a clear public reference for providing host-application launch context through the Embed SDK. This guide documents the required configuration and values in one place, making analytics integrations easier to implement consistently.

## How Has This Been Tested?

- Ran `npm run lint:skipdeadlinks` successfully with zero errors.
- Ran `git diff --check` successfully.
- Ran the complete documentation stack locally using Node.js v24.15.0.
- Confirmed the guide returned HTTP 200.
- Manually verified the **Analytics** navigation entry, page title, code examples, trigger values, TypeScript guidance, and API links.

Local route tested:

`http://localhost:3000/express/embed-sdk/docs/guides/concepts/host-app-trigger`

## Screenshots (if appropriate):

N/A — the rendered documentation page was verified locally.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All relevant documentation validation passed.